### PR TITLE
Add configurable preview downsampling filters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ takes down the whole session — prefer testing in a **nested** Hyprland instanc
 
 ## Architecture
 
-Three translation units, layered by Hyprland coupling:
+Four translation units, layered by Hyprland coupling:
 
 - **`src/main.cpp`** (~375 lines) — plugin entry points (`PLUGIN_INIT` / `PLUGIN_EXIT` /
   `PLUGIN_API_VERSION`) and nothing else. Registers all `plugin:gloview:*` config values,
@@ -100,6 +100,8 @@ Three translation units, layered by Hyprland coupling:
 - **`src/overview.{cpp,hpp}`** (~3450 lines) — the `Overview` class. All Hyprland-coupled
   logic: rendering, input, snapshot capture, animation, drag-and-drop, workspace ops.
   `overview.hpp` is the map of it, and its comments carry most of the hard-won reasoning.
+- **`src/preview_filter.{cpp,hpp}`** — scale-aware GPU downsampling for reduced live
+  previews, with Hyprland's normal surface pass as the compatibility fallback.
 - **`src/layout.{cpp,hpp}`** — **pure, Hyprland-independent** geometry. `LRect`, the
   `Engine` enum (`rows`/`grid`/`natural`), and `computeLayout()`. Add a layout engine here
   by extending `Engine` + `computeLayout` — the renderer and input code don't change.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ include(GNUInstallDirs)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(HYPR_DEPS REQUIRED hyprland)
+pkg_check_modules(GLESV2 REQUIRED IMPORTED_TARGET glesv2)
 # Lua's pkg-config module name varies by distro: `lua` (Arch), `lua5.4`/`lua-5.4`
 # (Debian/Nix), or `luajit` (what Hyprland itself links). Take the first that exists.
 pkg_search_module(LUA REQUIRED lua lua5.4 lua-5.4 lua54 luajit)
@@ -22,6 +23,7 @@ pkg_search_module(LUA REQUIRED lua lua5.4 lua-5.4 lua54 luajit)
 add_library(gloview SHARED
   src/main.cpp
   src/overview.cpp
+  src/preview_filter.cpp
   src/layout.cpp
 )
 set_target_properties(gloview PROPERTIES PREFIX "")  # produce gloview.so, not libgloview.so
@@ -34,7 +36,7 @@ foreach(inc ${HYPR_DEPS_INCLUDE_DIRS})
 endforeach()
 
 target_link_directories(gloview PRIVATE ${HYPR_DEPS_LIBRARY_DIRS} ${LUA_LIBRARY_DIRS})
-target_link_libraries(gloview PRIVATE ${HYPR_DEPS_LIBRARIES} ${LUA_LIBRARIES})
+target_link_libraries(gloview PRIVATE ${HYPR_DEPS_LIBRARIES} ${LUA_LIBRARIES} PkgConfig::GLESV2)
 
 install(TARGETS gloview LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ All keys live under `plugin:gloview:*`. Colors are `0xAARRGGBB` integers.
 | `padding_top` | int (px) | `40` | Extra gap between the strip and the previews |
 | `padding_bottom` | int (px) | `70` | Bottom outer margin |
 | `max_scale` | float | `1.0` | Never enlarge a preview past real size × this |
+| `preview_filter` | `box4` \| `box16` \| `linear` | `box4` | Scale-aware GPU downsampling for reduced previews: `box4` uses a 2×2 kernel, `box16` uses a smoother but costlier 4×4 kernel, and `linear` restores Hyprland's normal single-sample path |
 | `duration` | int (ms) | `360` | Open/close animation length |
 | `preview_round` | int (px) | `12` | Window preview corner radius |
 | `blur` | float `0`..`1` | `1.0` | Backdrop + strip blur strength (`0` = off; fractions allowed) |
@@ -173,6 +174,7 @@ supersedes the older `bar_position` (top/bottom only); set `anchor` and it wins.
                 padding_top    = 40,
                 padding_bottom = 70,
                 max_scale      = 1.0,
+                preview_filter = "box4",
                 duration       = 200,
                 preview_round  = 12,
                 blur           = 1,
@@ -257,6 +259,7 @@ plugin {
         padding_top = 40
         padding_bottom = 70
         max_scale = 1.0
+        preview_filter = box4
         duration = 200
         preview_round = 12
         blur = 1

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -149,6 +149,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     addInt("plugin:gloview:padding_top", Config::INTEGER{40});    // gap below the strip
     addInt("plugin:gloview:padding_bottom", Config::INTEGER{70}); // bottom margin
     addFloat("plugin:gloview:max_scale", Config::FLOAT{1.0F});    // never upscale past real*this
+    addStr("plugin:gloview:preview_filter", "box4");              // box4 | box16 | linear
     addInt("plugin:gloview:duration", Config::INTEGER{360});      // open/close animation (ms)
     addInt("plugin:gloview:preview_round", Config::INTEGER{12});
     addFloat("plugin:gloview:blur", Config::FLOAT{1.0F});         // backdrop/strip blur strength 0..1 (0 = off; floats allowed)

--- a/src/overview.cpp
+++ b/src/overview.cpp
@@ -1,4 +1,5 @@
 #include "overview.hpp"
+#include "preview_filter.hpp"
 
 #include <algorithm>
 #include <cctype>
@@ -161,11 +162,71 @@ LRect intersectRect(const LRect& a, const LRect& b) {
     return LRect{x0, y0, std::max(0.0, x1 - x0), std::max(0.0, y1 - y0)};
 }
 
+// Hyprland applies extra UV corrections while a surface and its window geometry disagree.
+// Use the custom filter only when its basic viewport UVs match the normal surface path.
+bool hasStablePreviewUV(const PHLWINDOW& window, const SP<CWLSurfaceResource>& surface, bool mainSurface,
+                        const CBox& texBoxLogical, const CBox& texBoxPx, const PHLMONITORREF& monitor) {
+    if (!window || !surface || !monitor || window->sizeAnimation()->isBeingAnimated())
+        return false;
+
+    const auto& drag = g_layoutManager->dragController();
+    if (drag && drag->target() == window->m_target && drag->mode() >= MBIND_RESIZE)
+        return false;
+
+    const auto& state = surface->m_current;
+    if (window->m_isX11 && state.viewport.hasSource)
+        return false;
+    if (texBoxLogical.size() != state.size)
+        return false;
+
+    Vector2D expectedPx;
+    if (state.viewport.hasDestination)
+        expectedPx = (state.viewport.destination * monitor->m_scale).round();
+    else if (state.viewport.hasSource)
+        expectedPx = (state.viewport.source.size() * monitor->m_scale).round();
+    else if (mainSurface && window->getReportedSize() != state.size)
+        expectedPx = (state.size * monitor->m_scale).round();
+    else if (mainSurface)
+        expectedPx = (window->getReportedSize() * monitor->m_scale).round();
+    else
+        expectedPx = texBoxPx.size();
+
+    if (texBoxPx.size() != expectedPx)
+        return false;
+
+    return true;
+}
+
+// Mirrors Hyprland's MISALIGNEDFSV1 correction in ElementRenderer: a fractional-scale
+// client can submit a scale-1 buffer that differs from the rounded projected size by one
+// or two pixels. Trim/extend the bottom-right UV so the source span matches the projected
+// surface exactly. Hyprland uses this with nearest-neighbour sampling; our corrected span
+// is instead safe to feed through box4/box16.
+void fixFractionalScaleUV(const SP<CWLSurfaceResource>& surface, const PHLMONITORREF& monitor,
+                          const Vector2D& projectedSizePx, Vector2D& uvMin, Vector2D& uvMax) {
+    if (!surface || !monitor)
+        return;
+
+    const auto& state      = surface->m_current;
+    const auto& bufferSize = state.bufferSize;
+    if (bufferSize.x <= 0.0 || bufferSize.y <= 0.0 || std::floor(monitor->m_scale) == monitor->m_scale ||
+        state.scale != 1 || projectedSizePx == bufferSize)
+        return;
+
+    const auto delta = projectedSizePx - bufferSize;
+    if (std::abs(delta.x) >= 3.0 || std::abs(delta.y) >= 3.0)
+        return;
+
+    const Vector2D misalignment = (uvMax - uvMin) * bufferSize - projectedSizePx;
+    if (misalignment != Vector2D{})
+        uvMax -= misalignment / bufferSize;
+}
+
 // Render a window's LIVE surface tree scaled into `destPx`, clipped to `clipPx`
 // (both monitor PIXEL coords) via real CSurfacePassElements. No crop rect to drift,
 // so immune to snapshots' stale/mis-cropped tiles; works on hidden workspaces.
 void renderWindowLive(const PHLWINDOW& w, const PHLMONITOR& mon, const CBox& destPx, const CBox& clipPx, float alpha, const Time::steady_tp& when,
-                      double roundSlotPx = 0.0) {
+                      int previewFilterGrid, double roundSlotPx = 0.0) {
     if (!w || !mon || !w->m_isMapped || !w->wlSurface() || !w->wlSurface()->resource())
         return;
     if (!(destPx.w > 0 && destPx.h > 0))
@@ -233,14 +294,52 @@ void renderWindowLive(const PHLWINDOW& w, const PHLMONITOR& mon, const CBox& des
     data.surfaceCounter = 0;
 
     w->wlSurface()->resource()->breadthfirst(
-        [&data, &w](SP<CWLSurfaceResource> s, const Vector2D& offset, void*) {
+        [&data, &w, &clipPx, &modif, previewFilterGrid](SP<CWLSurfaceResource> s, const Vector2D& offset, void*) {
             if (!s || !s->m_current.texture || s->m_current.size.x < 1 || s->m_current.size.y < 1)
                 return;
             data.localPos    = offset;
             data.texture     = s->m_current.texture;
             data.surface     = s;
             data.mainSurface = s == w->wlSurface()->resource();
-            g_pHyprRenderer->m_renderPass.add(makeUnique<CSurfacePassElement>(data));
+
+            if (previewFilterGrid == 0 || data.texture->m_type == Render::TEXTURE_EXTERNAL) {
+                g_pHyprRenderer->m_renderPass.add(makeUnique<CSurfacePassElement>(data));
+                data.surfaceCounter++;
+                return;
+            }
+
+            // Match CSurfacePassElement's size, rounding and animated-subsurface rules.
+            CSurfacePassElement geometry(data);
+            const CBox          texBoxLogical = geometry.getTexBox();
+            CBox                targetPx = texBoxLogical;
+            targetPx.scale(data.pMonitor->m_scale);
+            targetPx.round();
+            const bool stableUV = hasStablePreviewUV(w, s, data.mainSurface, texBoxLogical, targetPx, data.pMonitor);
+            const Vector2D projectedSizePx = targetPx.size();
+            modif.applyToBox(targetPx);
+
+            Vector2D uvMin{0.0, 0.0};
+            Vector2D uvMax{1.0, 1.0};
+            const auto& viewport = s->m_current.viewport;
+            const auto& bufferSize = s->m_current.bufferSize;
+            if (viewport.hasSource && bufferSize.x > 0.0 && bufferSize.y > 0.0) {
+                uvMin = Vector2D{viewport.source.x / bufferSize.x, viewport.source.y / bufferSize.y};
+                uvMax = Vector2D{(viewport.source.x + viewport.source.width) / bufferSize.x,
+                                 (viewport.source.y + viewport.source.height) / bufferSize.y};
+            }
+            if (stableUV)
+                fixFractionalScaleUV(s, data.pMonitor, projectedSizePx, uvMin, uvMax);
+
+            const Vector2D sampledPixels = (uvMax - uvMin) * data.texture->m_size;
+            const bool minifying = sampledPixels.x > targetPx.w * 1.05 || sampledPixels.y > targetPx.h * 1.05;
+            // Native-sized textures stay on Hyprland's normal path.
+            if (stableUV && minifying && targetPx.w > 1.0 && targetPx.h > 1.0) {
+                g_pHyprRenderer->m_renderPass.add(PreviewFilter::makePass(
+                    data, targetPx, clipPx, uvMin, uvMax, data.mainSurface && !data.dontRound ? data.rounding : 0.0,
+                    previewFilterGrid));
+            } else {
+                g_pHyprRenderer->m_renderPass.add(makeUnique<CSurfacePassElement>(data));
+            }
             data.surfaceCounter++;
         },
         nullptr);
@@ -349,6 +448,7 @@ Overview::~Overview() {
     // inactive overview and no dangling refs.
     m_active  = false;
     m_opening = false;
+    PreviewFilter::reset();
     restoreLayers(); // never leave a bar stuck at alpha 0 if we're torn down mid-hide
     restoreFill();   // never leave a window's surface stuck stretching its small buffer
     if (const auto ws = m_newWs.lock()) // don't leak a persistent workspace either
@@ -1570,6 +1670,9 @@ void Overview::renderStage(eRenderStage stage) {
     if (stage != RENDER_LAST_MOMENT)
         return;
 
+    const auto previewFilter = cfgStr("plugin:gloview:preview_filter", "box4");
+    m_previewFilterGrid = previewFilter == "box16" ? 4 : previewFilter == "box4" ? 2 : 0;
+
     updateAnimation();
     if (!m_active)
         return;
@@ -1785,7 +1888,7 @@ void Overview::renderStripWindows() const {
             const double stripRound = cropped ? 0.0 :
                                                 std::min(static_cast<double>(cfgInt("plugin:gloview:strip_card_round", 10)),
                                                          std::min(slot.w, slot.h) * 0.35);
-            renderWindowLive(w, m, slotPx, clipPx, static_cast<float>(e), when, stripRound);
+            renderWindowLive(w, m, slotPx, clipPx, static_cast<float>(e), when, m_previewFilterGrid, stripRound);
         }
     }
 }
@@ -2011,7 +2114,7 @@ void Overview::renderMainWindows() const {
             continue;
         const LRect lb = tileContentBox(i, currentBox(m_tiles[i], static_cast<int>(i)));
         const CBox  px(lb.x * scale, lb.y * scale, lb.w * scale, lb.h * scale);
-        renderWindowLive(w, m, px, px, 1.0F, when, static_cast<double>(cfgInt("plugin:gloview:preview_round", 12)));
+        renderWindowLive(w, m, px, px, 1.0F, when, m_previewFilterGrid, static_cast<double>(cfgInt("plugin:gloview:preview_round", 12)));
     }
 }
 
@@ -2054,7 +2157,7 @@ void Overview::renderPrevWindows() const {
         if (!w || !w->m_isMapped || w->isHidden())
             continue;
         const CBox px((t.target.x + off.x) * scale, (t.target.y + off.y) * scale, t.target.w * scale, t.target.h * scale);
-        renderWindowLive(w, m, px, px, 1.0F, when, round);
+        renderWindowLive(w, m, px, px, 1.0F, when, m_previewFilterGrid, round);
     }
 }
 
@@ -2101,7 +2204,7 @@ void Overview::renderFlyWindow() const {
             continue;
         const LRect lb = flyBox(f);
         const CBox  px(lb.x * scale, lb.y * scale, lb.w * scale, lb.h * scale);
-        renderWindowLive(w, m, px, px, 1.0F, when, flyRound(lb)); // opaque all the way — see renderFlyTile
+        renderWindowLive(w, m, px, px, 1.0F, when, m_previewFilterGrid, flyRound(lb)); // opaque all the way — see renderFlyTile
     }
 }
 
@@ -2126,7 +2229,8 @@ void Overview::renderDragWindow() const {
     const double scale = m->m_scale;
     const LRect  lb    = tileContentBox(static_cast<size_t>(dragIdx), dragBox());
     const CBox   px(lb.x * scale, lb.y * scale, lb.w * scale, lb.h * scale);
-    renderWindowLive(w, m, px, px, static_cast<float>(e), Time::steadyNow(), static_cast<double>(cfgInt("plugin:gloview:preview_round", 12)));
+    renderWindowLive(w, m, px, px, static_cast<float>(e), Time::steadyNow(), m_previewFilterGrid,
+                     static_cast<double>(cfgInt("plugin:gloview:preview_round", 12)));
 }
 
 bool Overview::isAboveLayer(const std::string& ns) const {

--- a/src/overview.hpp
+++ b/src/overview.hpp
@@ -150,6 +150,7 @@ class Overview {
     HANDLE                                m_handle = nullptr;
     bool                                  m_active = false;
     bool                                  m_opening = false;
+    int                                   m_previewFilterGrid = 2; // 0=linear, 2=box4, 4=box16
     // Close animation just hit progress 0 THIS frame. shouldRenderWindow (which
     // hides the real windows) is evaluated early in the frame, before our
     // RENDER_LAST_MOMENT pass; if we flipped m_active off mid-frame we'd skip

--- a/src/preview_filter.cpp
+++ b/src/preview_filter.cpp
@@ -1,0 +1,312 @@
+#include "preview_filter.hpp"
+
+#include <algorithm>
+#include <utility>
+
+#include <hyprland/src/config/ConfigValue.hpp>
+#include <hyprland/src/desktop/view/WLSurface.hpp>
+#include <hyprland/src/protocols/ColorManagement.hpp>
+#include <hyprland/src/protocols/core/Compositor.hpp>
+#include <hyprland/src/render/Framebuffer.hpp>
+#include <hyprland/src/render/OpenGL.hpp>
+#include <hyprland/src/render/Renderer.hpp>
+#include <hyprland/src/render/Texture.hpp>
+
+using Render::GL::g_pHyprOpenGL;
+
+namespace gloview::PreviewFilter {
+
+// Uses Hyprland's live surface textures directly; no capture or intermediate texture.
+namespace {
+
+// ---- shader -----------------------------------------------------------------
+
+constexpr char VERTEX_SHADER[] = R"(
+#version 300 es
+precision highp float;
+uniform mat3 proj;
+in vec2 pos;
+in vec2 texcoord;
+out vec2 v_texcoord;
+void main() {
+    gl_Position = vec4(proj * vec3(pos, 1.0), 1.0);
+    v_texcoord = texcoord;
+}
+)";
+
+// A 2x2 (box4) or 4x4 (box16) grid of bilinear reads covers each destination
+// pixel's source footprint.
+constexpr char FRAGMENT_SHADER[] = R"(
+#version 300 es
+precision highp float;
+in vec2 v_texcoord;
+uniform sampler2D tex;
+uniform vec2 footprint;
+uniform vec2 uv_min;
+uniform vec2 uv_max;
+uniform vec2 target_size;
+uniform int sample_grid;
+uniform float radius;
+uniform float rounding_power;
+uniform float alpha;
+uniform int force_opaque;
+layout(location = 0) out vec4 frag_color;
+
+const float PI = 3.1415926535897932384626433832795;
+const float SMOOTHING = PI / 5.34665792551;
+
+float rounded_alpha(vec2 pixel, float r) {
+    vec2 corner = pixel - target_size * 0.5;
+    corner *= vec2(lessThan(corner, vec2(0.0))) * -2.0 + 1.0;
+    corner -= target_size * 0.5 - r;
+    corner += vec2(1.0) / target_size;
+
+    if (corner.x + corner.y <= r)
+        return 1.0;
+
+    float distance = pow(pow(corner.x, rounding_power) + pow(corner.y, rounding_power), 1.0 / rounding_power);
+    if (distance > r + SMOOTHING)
+        discard;
+
+    return 1.0 - smoothstep(0.0, 1.0, (distance - r + SMOOTHING) / (SMOOTHING * 2.0));
+}
+
+void main() {
+    vec2 sample_uv = mix(uv_min, uv_max, v_texcoord);
+    vec2 pixel = v_texcoord * target_size;
+
+    vec2 half_texel = 0.5 / vec2(textureSize(tex, 0));
+    vec2 lo = min(uv_min + half_texel, uv_max);
+    vec2 hi = max(uv_max - half_texel, uv_min);
+    vec4 sum = vec4(0.0);
+    float grid = float(sample_grid);
+    for (int y = 0; y < 4; ++y) {
+        for (int x = 0; x < 4; ++x) {
+            if (x < sample_grid && y < sample_grid) {
+                vec2 offset = (vec2(float(x), float(y)) + 0.5) / grid - 0.5;
+                sum += texture(tex, clamp(sample_uv + offset * footprint, lo, hi));
+            }
+        }
+    }
+
+    frag_color = sum / (grid * grid);
+    if (force_opaque != 0)
+        frag_color.a = 1.0;
+    if (radius > 0.0)
+        frag_color *= rounded_alpha(pixel, radius);
+    frag_color *= alpha;
+}
+)";
+
+struct ShaderState {
+    SP<CShader> shader;
+    bool        unavailable = false;
+    GLint       footprint = -1;
+    GLint       uvMin = -1;
+    GLint       uvMax = -1;
+    GLint       targetSize = -1;
+    GLint       sampleGrid = -1;
+    GLint       radius = -1;
+    GLint       roundingPower = -1;
+    GLint       forceOpaque = -1;
+};
+
+ShaderState g_shader;
+
+bool ensureShader() {
+    if (g_shader.shader)
+        return true;
+    if (g_shader.unavailable || !g_pHyprOpenGL)
+        return false;
+
+    g_pHyprOpenGL->makeEGLCurrent();
+    auto shader = makeShared<CShader>();
+    if (!shader->createProgram(VERTEX_SHADER, FRAGMENT_SHADER, true, true)) {
+        g_shader.unavailable = true;
+        return false;
+    }
+
+    const auto program = shader->program();
+    g_shader.footprint   = glGetUniformLocation(program, "footprint");
+    g_shader.uvMin       = glGetUniformLocation(program, "uv_min");
+    g_shader.uvMax       = glGetUniformLocation(program, "uv_max");
+    g_shader.targetSize  = glGetUniformLocation(program, "target_size");
+    g_shader.sampleGrid  = glGetUniformLocation(program, "sample_grid");
+    g_shader.radius      = glGetUniformLocation(program, "radius");
+    g_shader.roundingPower = glGetUniformLocation(program, "rounding_power");
+    g_shader.forceOpaque = glGetUniformLocation(program, "force_opaque");
+    if (g_shader.footprint < 0 || g_shader.uvMin < 0 || g_shader.uvMax < 0 || g_shader.targetSize < 0 ||
+        g_shader.sampleGrid < 0 || g_shader.radius < 0 || g_shader.roundingPower < 0 || g_shader.forceOpaque < 0) {
+        shader.reset();
+        g_shader.unavailable = true;
+        return false;
+    }
+
+    g_shader.shader = std::move(shader);
+    return true;
+}
+
+struct SurfaceData {
+    CSurfacePassElement::SRenderData fallback;
+    CBox                            boxPx;
+    CBox                            clipPx;
+    Vector2D                        uvMin;
+    Vector2D                        uvMax{1.0, 1.0};
+    double                          radiusPx = 0.0;
+    int                             sampleGrid = 2;
+};
+
+// ---- render pass ------------------------------------------------------------
+
+CBox intersection(const CBox& a, const CBox& b) {
+    const double x0 = std::max(a.x, b.x);
+    const double y0 = std::max(a.y, b.y);
+    const double x1 = std::min(a.x + a.w, b.x + b.w);
+    const double y1 = std::min(a.y + a.h, b.y + b.h);
+    return CBox{x0, y0, std::max(0.0, x1 - x0), std::max(0.0, y1 - y0)};
+}
+
+bool swapsAxes(eTransform transform) {
+    return transform == HYPRUTILS_TRANSFORM_90 || transform == HYPRUTILS_TRANSFORM_270 ||
+        transform == HYPRUTILS_TRANSFORM_FLIPPED_90 || transform == HYPRUTILS_TRANSFORM_FLIPPED_270;
+}
+
+bool needsColorConversion(const SurfaceData& data) {
+    static auto enableCM = CConfigValue<Config::INTEGER>("render:cm_enabled");
+    if (!*enableCM || data.fallback.pMonitor->doesNoShaderCM())
+        return false;
+
+    auto source = data.fallback.texture->m_imageDescription;
+    if (!source && data.fallback.surface->m_colorManagement.valid())
+        source = NColorManagement::CImageDescription::from(data.fallback.surface->m_colorManagement->imageDescription());
+    if (!source)
+        source = NColorManagement::getDefaultImageDescription();
+
+    const auto& currentFB = g_pHyprRenderer->m_renderData.currentFB;
+    auto        target = data.fallback.pMonitor->workBufferImageDescription();
+    if (currentFB) {
+        const auto description = currentFB->imageDescription();
+        if (description)
+            target = description;
+    }
+
+    return target && source->needsCM(target);
+}
+
+bool drawSurface(const SurfaceData& data) {
+    const auto& fallback = data.fallback;
+    const auto& texture  = fallback.texture;
+    if (!texture || !texture->ok() || texture->m_type == Render::TEXTURE_EXTERNAL || !fallback.surface ||
+        !fallback.pMonitor || data.boxPx.w <= 1.0 || data.boxPx.h <= 1.0 || needsColorConversion(data) || !ensureShader())
+        return false;
+
+    const auto surface = Desktop::View::CWLSurface::fromResource(fallback.surface);
+    const float alpha = std::clamp(fallback.alpha * fallback.fadeAlpha *
+                                       (surface ? surface->m_alphaModifier * surface->m_overallOpacity : 1.0F),
+                                   0.0F, 1.0F);
+
+    auto transform = texture->m_transform;
+    if (g_pHyprRenderer->monitorTransformEnabled()) {
+        const auto monitorTransform = Math::wlTransformToHyprutils(Math::invertTransform(fallback.pMonitor->m_transform));
+        transform = Math::composeTransform(monitorTransform, transform);
+    }
+    // The filter footprint is expressed in destination X/Y. Rotated textures swap those
+    // axes, so leave them to Hyprland's normal surface renderer.
+    if (swapsAxes(transform))
+        return false;
+
+    const auto& projection = g_pHyprRenderer->projectBoxToTarget(data.boxPx, transform);
+
+    g_pHyprOpenGL->useShader(g_shader.shader);
+    g_shader.shader->setUniformMatrix3fv(SHADER_PROJ, 1, GL_TRUE, projection.getMatrix());
+    g_shader.shader->setUniformInt(SHADER_TEX, 0);
+    g_shader.shader->setUniformFloat(SHADER_ALPHA, alpha);
+    glUniform2f(g_shader.footprint, (data.uvMax.x - data.uvMin.x) / data.boxPx.w,
+                (data.uvMax.y - data.uvMin.y) / data.boxPx.h);
+    glUniform2f(g_shader.uvMin, data.uvMin.x, data.uvMin.y);
+    glUniform2f(g_shader.uvMax, data.uvMax.x, data.uvMax.y);
+    glUniform2f(g_shader.targetSize, data.boxPx.w, data.boxPx.h);
+    glUniform1i(g_shader.sampleGrid, data.sampleGrid == 4 ? 4 : 2);
+    glUniform1f(g_shader.radius, static_cast<float>(std::max(0.0, data.radiusPx - 1.0)));
+    glUniform1f(g_shader.roundingPower, fallback.roundingPower);
+    glUniform1i(g_shader.forceOpaque, texture->m_type == Render::TEXTURE_RGBX || texture->m_opaque ? 1 : 0);
+
+    glActiveTexture(GL_TEXTURE0);
+    texture->bind();
+    texture->setTexParameter(GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    texture->setTexParameter(GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    texture->setTexParameter(GL_TEXTURE_MAG_FILTER, texture->magFilter);
+    texture->setTexParameter(GL_TEXTURE_MIN_FILTER, texture->minFilter);
+    glBindVertexArray(g_shader.shader->getUniformLocation(SHADER_SHADER_VAO));
+
+    g_pHyprRenderer->blend(true);
+    const auto clipped = intersection(data.boxPx, data.clipPx);
+    if (clipped.w > 0.0 && clipped.h > 0.0) {
+        g_pHyprOpenGL->scissor(clipped);
+        glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+    }
+
+    g_pHyprOpenGL->scissor(static_cast<const pixman_box32*>(nullptr));
+    glBindVertexArray(0);
+    texture->unbind();
+
+    if (!g_pHyprRenderer->m_bBlockSurfaceFeedback)
+        fallback.surface->presentFeedback(fallback.when, fallback.pMonitor->m_self.lock());
+    if (fallback.surface->m_current.buffer && !fallback.surface->m_current.buffer->isSynchronous())
+        g_pHyprRenderer->m_usedAsyncBuffers.emplace_back(fallback.surface->m_current.buffer);
+    return true;
+}
+
+// Fall back to Hyprland's normal surface pass if the shader cannot draw.
+class SurfacePass final : public IPassElement {
+  public:
+    explicit SurfacePass(SurfaceData data) : m_data(std::move(data)) {}
+
+    std::vector<UP<IPassElement>> draw() override {
+        if (drawSurface(m_data))
+            return {};
+        std::vector<UP<IPassElement>> fallback;
+        fallback.emplace_back(makeUnique<CSurfacePassElement>(m_data.fallback));
+        return fallback;
+    }
+
+    bool needsLiveBlur() override { return false; }
+    bool needsPrecomputeBlur() override { return false; }
+    void discard() override { CSurfacePassElement(m_data.fallback).discard(); }
+    const char* passName() override { return "GloViewPreviewFilter"; }
+    ePassElementType type() override { return EK_CUSTOM; }
+    std::optional<CBox> boundingBox() override {
+        if (!m_data.fallback.pMonitor || m_data.fallback.pMonitor->m_scale <= 0.0)
+            return std::nullopt;
+        const double scale = m_data.fallback.pMonitor->m_scale;
+        const auto   clipped = intersection(m_data.boxPx, m_data.clipPx);
+        return CBox{clipped.x / scale, clipped.y / scale, clipped.w / scale, clipped.h / scale};
+    }
+
+  private:
+    SurfaceData m_data;
+};
+
+} // namespace
+
+UP<IPassElement> makePass(CSurfacePassElement::SRenderData fallback, const CBox& boxPx, const CBox& clipPx,
+                          const Vector2D& uvMin, const Vector2D& uvMax, double radiusPx, int sampleGrid) {
+    return makeUnique<SurfacePass>(SurfaceData{
+        .fallback = std::move(fallback),
+        .boxPx = boxPx,
+        .clipPx = clipPx,
+        .uvMin = uvMin,
+        .uvMax = uvMax,
+        .radiusPx = radiusPx,
+        .sampleGrid = sampleGrid,
+    });
+}
+
+void reset() {
+    if (g_shader.shader && g_pHyprOpenGL)
+        g_pHyprOpenGL->makeEGLCurrent();
+    g_shader.shader.reset();
+    g_shader = {};
+}
+
+} // namespace gloview::PreviewFilter

--- a/src/preview_filter.hpp
+++ b/src/preview_filter.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <hyprland/src/render/pass/PassElement.hpp>
+#include <hyprland/src/render/pass/SurfacePassElement.hpp>
+
+namespace gloview::PreviewFilter {
+
+// Draws a live surface through a sampleGrid x sampleGrid box filter. Supported
+// grids are 2 (box4) and 4 (box16).
+[[nodiscard]] UP<IPassElement> makePass(CSurfacePassElement::SRenderData fallback, const CBox& boxPx, const CBox& clipPx,
+                                        const Vector2D& uvMin, const Vector2D& uvMax, double radiusPx, int sampleGrid);
+
+// Releases GL objects before the plugin is unloaded.
+void reset();
+
+} // namespace gloview::PreviewFilter


### PR DESCRIPTION
## What changed?

- Add a custom GLES preview pass that downsamples reduced live window previews across each destination pixel's source footprint.
- Add `plugin:gloview:preview_filter` with three live-configurable modes:
  - `box4` (default): 2x2 sample grid.
  - `box16`: smoother 4x4 sample grid at a higher GPU cost.
  - `linear`: Hyprland's normal surface pass.
- Correct the sampled UV span for fractional-scale client buffers, including the small rounded-size mismatch seen with Chromium surfaces.
- Preserve clipping, rounded corners, opacity, presentation feedback, and async-buffer tracking. Unsupported or color-managed paths fall back to Hyprland's normal surface renderer.
- Document the new setting and link the GLESv2 dependency.

## Why?

Reduced window previews currently use a single bilinear sample per destination pixel. At fractional output scales this visibly aliases fine text and high-frequency UI detail, with Chromium windows being an especially clear example.

The new box filters integrate a wider source footprint when the preview is smaller than the source. `box4` provides a moderate default improvement, while `box16` offers the smoothest result for users who prefer image quality over the additional sampling cost. `linear` remains available as the compatibility baseline.

## Before / after — workspace row thumbnail

Captured from the same workspace card at GloView's normal strip size and layout. The window is Chromium showing the upstream GloView GitHub repository; only `preview_filter` changes between frames.

### Before — `linear`
<img width="416" height="280" alt="gloview-row-before-linear" src="https://github.com/user-attachments/assets/e674257d-e32e-44c0-9cf0-a50eaa98b9d8" />


### After — `box16`
<img width="416" height="280" alt="gloview-row-after-box16" src="https://github.com/user-attachments/assets/edaebdef-cbf5-4ca3-a601-dcda239c4d20" />



## Environment

- Hyprland version: 0.56.2 (`efb50993780079460b0cbed1363e2166a2de1d9f`)
- GPU / driver: AMD Radeon Vega (Picasso/Raven 2), `amdgpu`
- Monitors: 3840x2160@60 Hz, scale 1.6

## Checks

- [x] Builds
- [x] Ran in a live Hyprland via `cmake --build build --target reload`
- [x] README updated if a `plugin:gloview:*` option was added or changed

